### PR TITLE
fix module name in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,24 @@ A comprehensive package providing separate DatePicker and TimePicker components 
 This package supports Angular 14 and above. Specific version compatibility:
 
 | Package Version | Angular Version |
-|----------------|-----------------|
-| 1.x.x          | ≥14.0.0        |
+| --------------- | --------------- |
+| 1.x.x           | ≥14.0.0         |
 
 ## Demo
+
 You can see the online [Demo](https://datepicker.qydr.ir/)
 
 ## Components
+
 This package includes two main components:
+
 1. `QeydarDatePicker`: A flexible date picker with range selection support and time selection
 2. `QeydarTimePicker`: A standalone time picker with 12/24 hour format support
 
 ## Features
+
 ### DatePicker
+
 - 📅 Support for both Jalali (Persian) and Gregorian calendars
 - 🎯 Single date and date range selection
 - ⏰ Integrated time selection support
@@ -42,6 +47,7 @@ This package includes two main components:
 - 🔒 Read-only mode support
 
 ### TimePicker
+
 - ⏰ 12/24 hour format support
 - ⏱️ Optional seconds display
 - 🔒 Time range restrictions
@@ -58,6 +64,7 @@ npm install @angular/cdk@<COMPATIBLE_VERSION> @qeydar/datepicker
 ```
 
 ### Dependencies
+
 ```json
 {
   "@angular/cdk": ">=14.0.0",
@@ -67,37 +74,40 @@ npm install @angular/cdk@<COMPATIBLE_VERSION> @qeydar/datepicker
 ```
 
 ### Required Styles
+
 ```css
-@import '@angular/cdk/overlay-prebuilt.css';
+@import "@angular/cdk/overlay-prebuilt.css";
 ```
 
 ## DatePicker Usage
 
 ### Basic Usage
+
 ```typescript
 // app.module.ts
-import { QeydarDatepickerModule } from '@qeydar/datepicker';
+import { QeydarDatePickerModule } from "@qeydar/datepicker";
 
 @NgModule({
-  imports: [QeydarDatepickerModule]
+  imports: [QeydarDatePickerModule],
 })
-export class AppModule { }
+export class AppModule {}
 
 // component.ts
 @Component({
   template: `
-    <qeydar-date-picker 
+    <qeydar-date-picker
       [(ngModel)]="selectedDate"
       [calendarType]="'jalali'"
     ></qeydar-date-picker>
-  `
+  `,
 })
 export class AppComponent {
-  selectedDate: Date | string = '1403/01/01'; // Can accept both Date object and string
+  selectedDate: Date | string = "1403/01/01"; // Can accept both Date object and string
 }
 ```
 
 ### Range Selection
+
 The DatePicker supports flexible range selection with multiple ways to handle values:
 
 ```typescript
@@ -110,36 +120,37 @@ The DatePicker supports flexible range selection with multiple ways to handle va
       [emitInDateFormat]="false"
       [calendarType]="'jalali'"
     ></qeydar-date-picker>
-  `
+  `,
 })
 export class AppComponent {
   // Using string values
   dateRange = {
-    start: '1403/08/12',
-    end: '1403/08/15'
+    start: "1403/08/12",
+    end: "1403/08/15",
   };
 
   // Using mixed values (string and Date)
   dateRange2 = {
-    start: '1403/08/12',
-    end: new Date()
+    start: "1403/08/12",
+    end: new Date(),
   };
 
   // Using Date objects
   dateRange3 = {
-    start: new Date('2024-01-01'),
-    end: new Date('2024-01-07')
+    start: new Date("2024-01-01"),
+    end: new Date("2024-01-07"),
   };
 
   // With emitInDateFormat=true, values will be emitted as Date objects
-  onRangeChange(range: { start: Date, end: Date }) {
-    console.log('Start:', range.start);
-    console.log('End:', range.end);
+  onRangeChange(range: { start: Date; end: Date }) {
+    console.log("Start:", range.start);
+    console.log("End:", range.end);
   }
 }
 ```
 
 ### Range Selection with Predefined Periods
+
 ```typescript
 // Define custom period labels
 const customLabels: CustomLabels[] = [
@@ -170,17 +181,18 @@ const customLabels: CustomLabels[] = [
 ```
 
 ### Date and Time Selection
+
 ```typescript
 @Component({
   template: `
-    <qeydar-date-picker 
+    <qeydar-date-picker
       [(ngModel)]="selectedDateTime"
       [format]="'yyyy/MM/dd HH:mm:ss'"
       [showTimePicker]="true"
       [timeDisplayFormat]="'HH:mm'"
       [showToday]="true"
     ></qeydar-date-picker>
-  `
+  `,
 })
 export class AppComponent {
   selectedDateTime: Date | string = new Date();
@@ -188,6 +200,7 @@ export class AppComponent {
 ```
 
 ### Value Format Options
+
 ```typescript
 @Component({
   template: `
@@ -201,6 +214,7 @@ export class AppComponent {
 ```
 
 ### Disabled Dates
+
 ```typescript
 @Component({
   template: `
@@ -209,14 +223,14 @@ export class AppComponent {
       [disabledDates]="disabledDates"
       [disabledDatesFilter]="disabledDatesFilter"
     ></qeydar-date-picker>
-  `
+  `,
 })
 export class AppComponent {
   // These will disable the entire day
   disabledDates = [
-    new Date(2024, 0, 1),  // Jan 1, 2024
+    new Date(2024, 0, 1), // Jan 1, 2024
     new Date(2024, 11, 25), // Dec 25, 2024
-    '2024/01/15'  // Jan 15, 2024
+    "2024/01/15", // Jan 15, 2024
   ];
 
   // This will disable specific days advanced
@@ -228,6 +242,7 @@ export class AppComponent {
 ```
 
 ### Custom Templates
+
 The DatePicker now supports custom templates for days, months, and years, allowing you to customize how these elements are rendered:
 
 ```typescript
@@ -259,7 +274,7 @@ The DatePicker now supports custom templates for days, months, and years, allowi
         </div>
       </ng-template>
     </qeydar-date-picker>
-  `
+  `,
 })
 export class AppComponent {
   isSpecialDay(date: Date): boolean {
@@ -270,6 +285,7 @@ export class AppComponent {
 ```
 
 ### Read-only Mode
+
 The DatePicker now supports two types of read-only modes:
 
 ```typescript
@@ -304,10 +320,10 @@ The TimePicker is a separate component for time selection:
       [minTime]="'09:00'"
       [maxTime]="'17:00'"
     ></qeydar-time-picker>
-  `
+  `,
 })
 export class AppComponent {
-  selectedTime = '14:30:00';
+  selectedTime = "14:30:00";
 
   // Or using Date object with valueType="date"
   selectedDateTime = new Date();
@@ -315,6 +331,7 @@ export class AppComponent {
 ```
 
 ### TimePicker with Custom Format
+
 ```typescript
 <qeydar-time-picker
   [(ngModel)]="time"
@@ -326,6 +343,7 @@ export class AppComponent {
 ```
 
 ### Inline Mode with Date Adapter
+
 ```typescript
 @Component({
   template: `
@@ -344,6 +362,7 @@ export class AppComponent {
 ```
 
 ### Disabled Times
+
 ```typescript
 @Component({
   template: `
@@ -351,94 +370,96 @@ export class AppComponent {
       [(ngModel)]="selectedTime"
       [disabledTimesFilter]="disabledTimesFilter"
     ></qeydar-time-picker>
-  `
+  `,
 })
 export class AppComponent {
   // Disable lunch hours (12:00-13:00)
   disabledTimesFilter = (date: Date) => {
     const hour = date.getHours();
     const minute = date.getMinutes();
-    
+
     // Disable specific hour
     if (hour === 12) return true;
-    
+
     // Disable specific minutes
     if (minute === 45) return true;
-    
+
     return false;
-  }
+  };
 }
 ```
 
 ## API Reference
 
 ### DatePicker Inputs
-| Input             | Type                     | Default       | Description |
-|-------------------|--------------------------|---------------|-------------|
-| rtl               | boolean                  | false         | Right-to-left mode |
-| mode              | 'day' \| 'month' \| 'year' | 'day'       | Selection mode |
-| isRange           | boolean                  | false         | Enable range selection |
-| format            | string                   | 'yyyy/MM/dd'  | Date format |
-| calendarType      | 'jalali' \| 'gregorian'  | 'gregorian'   | Calendar type |
-| minDate           | Date                     | null          | Minimum selectable date |
-| maxDate           | Date                     | null          | Maximum selectable date |
-| cssClass          | string                   | ''            | Custom CSS class |
-| footerDescription | string                   | ''            | Footer description text |
-| rangeInputLabels  | RangeInputLabels         | undefined     | Labels for range inputs |
-| inputLabel        | string                   | undefined     | Label for single input |
-| placement         | Placement                | 'bottomLeft'  | Dropdown placement |
-| disabled          | boolean                  | false         | Disable the datepicker |
-| isInline          | boolean                  | false         | Show calendar inline |
-| showSidebar       | boolean                  | true          | Show sidebar with months/years |
-| showToday         | boolean                  | false         | Highlight today's date |
-| valueFormat       | 'gregorian' \| 'jalali' \| 'date' | 'gregorian' | Output value format |
-| disableInputMask  | boolean                  | false         | To disable input mask |
-| disabledDates     | Arrar<Date || string>    | undefined     | Array of Date and string to disable the entire day |
-| disabledDatesFilter | (date: Date) => boolean| undefined     | Function to determine if a date should be disabled |
-| disabledTimesFilter| (date: Date) => boolean | undefined     | Function to determine if a time of date should be disabled |
-| allowEmpty         | boolean                 | true          | Allow empty value |
-| readOnly          | boolean                  | false         | Make the entire component read-only |
-| readOnlyInput     | boolean                  | false         | Make only the input field read-only |
+
+| Input               | Type                              | Default      | Description                                                |
+| ------------------- | --------------------------------- | ------------ | ---------------------------------------------------------- | --------- | -------------------------------------------------- |
+| rtl                 | boolean                           | false        | Right-to-left mode                                         |
+| mode                | 'day' \| 'month' \| 'year'        | 'day'        | Selection mode                                             |
+| isRange             | boolean                           | false        | Enable range selection                                     |
+| format              | string                            | 'yyyy/MM/dd' | Date format                                                |
+| calendarType        | 'jalali' \| 'gregorian'           | 'gregorian'  | Calendar type                                              |
+| minDate             | Date                              | null         | Minimum selectable date                                    |
+| maxDate             | Date                              | null         | Maximum selectable date                                    |
+| cssClass            | string                            | ''           | Custom CSS class                                           |
+| footerDescription   | string                            | ''           | Footer description text                                    |
+| rangeInputLabels    | RangeInputLabels                  | undefined    | Labels for range inputs                                    |
+| inputLabel          | string                            | undefined    | Label for single input                                     |
+| placement           | Placement                         | 'bottomLeft' | Dropdown placement                                         |
+| disabled            | boolean                           | false        | Disable the datepicker                                     |
+| isInline            | boolean                           | false        | Show calendar inline                                       |
+| showSidebar         | boolean                           | true         | Show sidebar with months/years                             |
+| showToday           | boolean                           | false        | Highlight today's date                                     |
+| valueFormat         | 'gregorian' \| 'jalali' \| 'date' | 'gregorian'  | Output value format                                        |
+| disableInputMask    | boolean                           | false        | To disable input mask                                      |
+| disabledDates       | Arrar<Date                        |              | string>                                                    | undefined | Array of Date and string to disable the entire day |
+| disabledDatesFilter | (date: Date) => boolean           | undefined    | Function to determine if a date should be disabled         |
+| disabledTimesFilter | (date: Date) => boolean           | undefined    | Function to determine if a time of date should be disabled |
+| allowEmpty          | boolean                           | true         | Allow empty value                                          |
+| readOnly            | boolean                           | false        | Make the entire component read-only                        |
+| readOnlyInput       | boolean                           | false        | Make only the input field read-only                        |
 
 ### DatePicker Outputs
-| Output        | Type                  | Description |
-|--------------|----------------------|-------------|
-| onFocus      | EventEmitter<any>    | Fires when input receives focus |
-| onBlur       | EventEmitter<any>    | Fires when input loses focus |
-| onChangeValue | EventEmitter<any>    | Fires when value changes |
-| onOpenChange  | EventEmitter<boolean> | Fires when picker opens/closes |
 
+| Output        | Type                  | Description                     |
+| ------------- | --------------------- | ------------------------------- |
+| onFocus       | EventEmitter<any>     | Fires when input receives focus |
+| onBlur        | EventEmitter<any>     | Fires when input loses focus    |
+| onChangeValue | EventEmitter<any>     | Fires when value changes        |
+| onOpenChange  | EventEmitter<boolean> | Fires when picker opens/closes  |
 
 ### TimePicker Inputs
 
-| Input          | Type                | Default      | Description |
-|----------------|---------------------|--------------|-------------|
-| placeholder    | string             | 'Select time' | Input placeholder |
-| displayFormat  | string             | 'hh:mm a'    | Time display format |
-| minTime        | string             | undefined    | Minimum selectable time |
-| maxTime        | string             | undefined    | Maximum selectable time |
-| valueType      | 'string' \| 'date' | 'string'     | Output value type |
-| cssClass       | string             | ''           | Custom CSS class |
-| showIcon       | boolean            | true         | Show clock icon |
-| rtl            | boolean            | false        | Right-to-left mode |
-| lang           | Lang_Locale        | lang_En      | Language settings |
-| inline         | boolean            | false        | Show time picker inline (without popup) |
-| dateAdapter    | DateAdapter<Date>  | undefined    | Custom date adapter for time manipulation |
-| disableInputMask  | boolean         | false        | To disable input mask |
-| disabledTimesFilter| (date: Date) => boolean| undefined| Function to determine if a time should be disabled |
-| disabled           | boolean                | false   | Disable the time picker |
-| allowEmpty         | boolean                | true    | Allow empty value |
+| Input               | Type                    | Default       | Description                                        |
+| ------------------- | ----------------------- | ------------- | -------------------------------------------------- |
+| placeholder         | string                  | 'Select time' | Input placeholder                                  |
+| displayFormat       | string                  | 'hh:mm a'     | Time display format                                |
+| minTime             | string                  | undefined     | Minimum selectable time                            |
+| maxTime             | string                  | undefined     | Maximum selectable time                            |
+| valueType           | 'string' \| 'date'      | 'string'      | Output value type                                  |
+| cssClass            | string                  | ''            | Custom CSS class                                   |
+| showIcon            | boolean                 | true          | Show clock icon                                    |
+| rtl                 | boolean                 | false         | Right-to-left mode                                 |
+| lang                | Lang_Locale             | lang_En       | Language settings                                  |
+| inline              | boolean                 | false         | Show time picker inline (without popup)            |
+| dateAdapter         | DateAdapter<Date>       | undefined     | Custom date adapter for time manipulation          |
+| disableInputMask    | boolean                 | false         | To disable input mask                              |
+| disabledTimesFilter | (date: Date) => boolean | undefined     | Function to determine if a time should be disabled |
+| disabled            | boolean                 | false         | Disable the time picker                            |
+| allowEmpty          | boolean                 | true          | Allow empty value                                  |
 
 ### TimePicker Outputs
 
-| Output      | Type                   | Description |
-|-------------|------------------------|-------------|
-| timeChange  | EventEmitter<any>      | Fires when time changes |
-| openChange  | EventEmitter<boolean>  | Fires when picker opens/closes |
+| Output     | Type                  | Description                    |
+| ---------- | --------------------- | ------------------------------ |
+| timeChange | EventEmitter<any>     | Fires when time changes        |
+| openChange | EventEmitter<boolean> | Fires when picker opens/closes |
 
 ## Form Integration Examples
 
 ### Reactive Forms with Both Components
+
 ```typescript
 @Component({
   template: `
@@ -456,21 +477,25 @@ export class AppComponent {
         [timeFormat]="'24'"
       ></qeydar-time-picker>
     </form>
-  `
+  `,
 })
 export class AppComponent {
   form = this.fb.group({
-    dateRange: [{
-      start: '1403/08/12',
-      end: new Date()
-    }],
-    time: ['14:30']
+    dateRange: [
+      {
+        start: "1403/08/12",
+        end: new Date(),
+      },
+    ],
+    time: ["14:30"],
   });
 
   constructor(private fb: FormBuilder) {}
 }
 ```
+
 #### Inline Mode
+
 ```typescript
 <qeydar-time-picker
   [(ngModel)]="time"
@@ -481,6 +506,7 @@ export class AppComponent {
 ```
 
 ### Calendar Types and Localization
+
 The TimePicker automatically adapts to your chosen calendar system:
 
 ```typescript
@@ -498,7 +524,9 @@ The TimePicker automatically adapts to your chosen calendar system:
   [timeFormat]="'24'"
 ></qeydar-time-picker>
 ```
+
 ### Template-driven Forms
+
 ```typescript
 <form #form="ngForm">
   <qeydar-date-picker
@@ -517,7 +545,9 @@ The TimePicker automatically adapts to your chosen calendar system:
 ```
 
 ## Styling
+
 Both components can be styled using CSS variables:
+
 ```css
 .qeydar-time-picker {
   --primary-color: #40a9ff;
@@ -538,7 +568,9 @@ Both components can be styled using CSS variables:
 ```
 
 ## Contributing
+
 Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## License
+
 MIT License


### PR DESCRIPTION
this PR will fix the wrong name for QeydarDatePickerModule in the documentation.

```QeydarDatepickerModule``` to ```QeydarDatePickerModule```  